### PR TITLE
Fix JavaScript module loading in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,11 +7,8 @@
   <link rel="stylesheet" href="./styles/style.css" />
   <style>#enterAR{position:fixed;left:50%;top:50%;transform:translate(-50%,-50%);background:#fff;border:none;border-radius:999px;padding:12px 16px;font-weight:700;box-shadow:0 10px 30px rgba(0,0,0,.25)}</style>
   <script src="https://unpkg.com/three@0.160.0/build/three.min.js"></script>
-  <script src="https://unpkg.com/three@0.160.0/examples/jsm/webxr/ARButton.js"></script>
   <script src="https://unpkg.com/three@0.160.0/examples/js/loaders/PLYLoader.js"></script>
-  <script defer src="./scripts/ovalShadowShader.js"></script>
-  <script defer src="./scripts/gestureControls.js"></script>
-  <script defer src="./scripts/app.js"></script>
+  <script type="module" defer src="./scripts/app.js"></script>
 </head>
 <body>
   <div id="ui">


### PR DESCRIPTION
The application was failing to load due to JavaScript syntax errors. This was caused by ES module scripts (using `import`/`export`) being loaded as classic scripts.

This change corrects the `<script>` tags in `index.html`:
- The main application script (`app.js`) is now correctly loaded with `type="module"`.
- Redundant script tags for dependencies that are imported by `app.js` have been removed.
- An unused and incorrectly loaded `ARButton.js` script has been removed.

This should resolve the console errors and allow the application to run correctly.